### PR TITLE
fix: implement automatic toast message clearing in ControversiesPage for improved user experience

### DIFF
--- a/src/app/[lng]/controversies/page.tsx
+++ b/src/app/[lng]/controversies/page.tsx
@@ -47,10 +47,20 @@ export default function ControversiesPage({ params: paramsPromise }: { params: P
 
   const showToast = (message: string) => {
     setToastMessage(message);
-    setTimeout(() => {
+  };
+
+  // Automatically clear toast after 3 seconds and clean up on unmount
+  useEffect(() => {
+    if (!toastMessage) return;
+
+    const timer: ReturnType<typeof setTimeout> = setTimeout(() => {
       setToastMessage(null);
     }, 3000);
-  };
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [toastMessage]);
 
   useEffect(() => {
     if (!dict) return;


### PR DESCRIPTION
fixed:
- showToast now only sets the toast message (no setTimeout inside)
- A dedicated useEffect watches toastMessage, starts a 3-second timer to clear it, and returns a cleanup function that cancels the timer when the component unmounts or the message changes, eliminating the potential memory leak

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of toast notifications, ensuring they automatically disappear after 3 seconds and preventing overlapping timers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->